### PR TITLE
Implement soft-delete contact workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Features
 --------
 
 - add a contact with an auto-assigned ID
-- display all contacts in a formatted table
+- display active contacts by default, with explicit views for all or inactive contacts
 - search for a contact by ID
 - edit an existing contact's name, age, gender, or balance
 - deactivate a contact without deleting it
@@ -31,6 +31,17 @@ Each contact stores:
 - `gender`: `M` or `F`
 - `balance`: floating-point account balance
 - `isActive`: active/inactive status flag
+
+Soft-Delete Behavior
+--------------------
+
+Deactivation is implemented as a soft delete:
+
+- deactivated contacts remain in memory
+- default listing shows active contacts only
+- the menu includes an explicit view for all contacts or inactive contacts
+- search by ID still finds inactive contacts and shows their active status
+- editing by ID is still allowed for inactive contacts
 
 Persistence Approach
 --------------------
@@ -107,10 +118,11 @@ The transcript below is based on a real run of the current executable:
 ****************************************************
 *         Welcome to Contact Manager!              *
 *           1. Add Contact                         *
-*           2. Display Contacts                    *
+*           2. Display Active Contacts             *
 *           3. Search Contact by ID                *
 *           4. Edit Contact                        *
 *           5. Deactivate Contact                  *
+*           6. View All/Inactive Contacts          *
 *           0. Exit                                *
 ****************************************************
 Enter your choice: 1

--- a/include/ContactBook.h
+++ b/include/ContactBook.h
@@ -4,7 +4,8 @@
 #include <string>
 #include <vector>
 
-struct Contact {
+struct Contact
+{
     int id;
     std::string name;
     unsigned int age;
@@ -13,14 +14,30 @@ struct Contact {
     bool isActive;
 };
 
-class ContactBook {
+enum class ContactFilter
+{
+    Active,
+    Inactive,
+    All
+};
+
+enum class DeactivateResult
+{
+    Success,
+    NotFound,
+    AlreadyInactive
+};
+
+class ContactBook
+{
 public:
     int add(Contact contact);
     Contact* findById(int id);
     const Contact* findById(int id) const;
     const std::vector<Contact>& all() const;
     bool updateContact(int id, const Contact& updatedContact);
-    bool deactivate(int id);
+    std::vector<Contact> getContacts(ContactFilter filter) const;
+    DeactivateResult deactivate(int id);
 
 private:
     std::vector<Contact> contacts_;

--- a/src/ContactBook.cpp
+++ b/src/ContactBook.cpp
@@ -38,6 +38,29 @@ const std::vector<Contact>& ContactBook::all() const
     return contacts_;
 }
 
+std::vector<Contact> ContactBook::getContacts(ContactFilter filter) const
+{
+    std::vector<Contact> filteredContacts;
+
+    for (const Contact& contact : contacts_)
+    {
+        if (filter == ContactFilter::All)
+        {
+            filteredContacts.push_back(contact);
+        }
+        else if (filter == ContactFilter::Active && contact.isActive)
+        {
+            filteredContacts.push_back(contact);
+        }
+        else if (filter == ContactFilter::Inactive && !contact.isActive)
+        {
+            filteredContacts.push_back(contact);
+        }
+    }
+
+    return filteredContacts;
+}
+
 bool ContactBook::updateContact(int id, const Contact& updatedContact)
 {
     Contact* contact = findById(id);
@@ -54,14 +77,19 @@ bool ContactBook::updateContact(int id, const Contact& updatedContact)
     return true;
 }
 
-bool ContactBook::deactivate(int id)
+DeactivateResult ContactBook::deactivate(int id)
 {
     Contact* contact = findById(id);
     if (contact == nullptr)
     {
-        return false;
+        return DeactivateResult::NotFound;
+    }
+    
+    if (!contact->isActive)
+    {
+        return DeactivateResult::AlreadyInactive;
     }
 
     contact->isActive = false;
-    return true;
+    return DeactivateResult::Success;
 }

--- a/src/ContactMenu.cpp
+++ b/src/ContactMenu.cpp
@@ -7,6 +7,56 @@ using std::cout;
 
 namespace
 {
+    void printMainMenu()
+    {
+        cout << "****************************************************" << '\n';
+        cout << "*         Welcome to Contact Manager!              *" << '\n';
+        cout << "*           1. Add Contact                         *" << '\n';
+        cout << "*           2. Display Active Contacts             *" << '\n';
+        cout << "*           3. Search Contact by ID                *" << '\n';
+        cout << "*           4. Edit Contact                        *" << '\n';
+        cout << "*           5. Deactivate Contact                  *" << '\n';
+        cout << "*           6. View All/Inactive Contacts          *" << '\n';
+        cout << "*           0. Exit                                *" << '\n';
+        cout << "****************************************************" << '\n';
+    }
+
+    void printContactTableHeader()
+    {
+        cout << std::setw(10) << std::left << "ID"
+            << std::setw(20) << std::left << "Name"
+            << std::setw(10) << std::left << "Age"
+            << std::setw(10) << std::left << "Gender"
+            << std::setw(15) << std::left << "Balance"
+            << std::setw(10) << std::left << "Active" << '\n';
+    }
+
+    void printContactRow(const Contact& contact)
+    {
+        cout << std::setw(10) << contact.id
+            << std::setw(20) << contact.name
+            << std::setw(10) << contact.age
+            << std::setw(10) << contact.gender
+            << std::setw(15) << contact.balance
+            << std::setw(10) << (contact.isActive ? "Yes" : "No") << '\n';
+    }
+
+    void printContacts(const std::vector<Contact>& contacts)
+    {
+        if (contacts.empty())
+        {
+            cout << "There are no contacts to display." << '\n';
+            return;
+        }
+
+        printContactTableHeader();
+
+        for (const Contact& contact : contacts)
+        {
+            printContactRow(contact);
+        }
+    }
+
     Contact* promptForExistingContact(ContactBook& book, const std::string& prompt)
     {
         while (true)
@@ -27,6 +77,215 @@ namespace
             cout << "Contact with that ID was not found. Please try again." << '\n';
         }
     }
+
+    void handleAddContact(ContactBook& book)
+    {
+        Contact newContact;
+        newContact.name = promptRequiredText(
+            "Enter Name: ",
+            "Name cannot be empty."
+        );
+        newContact.age = static_cast<unsigned int>(promptIntInRange(
+            "Enter Age: ",
+            0,
+            150,
+            "Invalid age. Enter a whole number from 0 to 150."
+        ));
+        newContact.gender = promptGender(
+            "Enter Gender (M/F): ",
+            "Invalid gender. Enter M or F."
+        );
+        newContact.balance = promptFloatInRange(
+            "Enter Balance: ",
+            0.0f,
+            1000000.0f,
+            "Invalid balance. Enter a non-negative number."
+        );
+        newContact.isActive = true;
+
+        int assignedId = book.add(newContact);
+        cout << "Contact added successfully! ID: " << assignedId << '\n';
+    }
+
+    void handleSearchContactById(const ContactBook& book)
+    {
+        if (book.all().empty())
+        {
+            cout << "There are no contacts to search." << '\n';
+            return;
+        }
+
+        int id = promptIntInRange(
+            "Enter Contact ID to search: ",
+            1,
+            1000000,
+            "Invalid ID. Enter a positive whole number."
+        );
+
+        const Contact* contact = book.findById(id);
+
+        if (contact != nullptr)
+        {
+            if (!contact->isActive)
+            {
+                cout << "This contact is inactive." << '\n';
+            }
+
+            printContactTableHeader();
+            printContactRow(*contact);
+        }
+        else
+        {
+            cout << "Contact with ID " << id << " not found." << '\n';
+        }
+    }
+
+    void handleEditContact(ContactBook& book)
+    {
+        if (book.all().empty())
+        {
+            cout << "There are no contacts to edit." << '\n';
+            return;
+        }
+
+        Contact* contact = promptForExistingContact(
+            book,
+            "Enter Contact ID to edit: "
+        );
+        Contact updatedContact = *contact;
+        int editChoice;
+
+        do
+        {
+            cout << "1. Edit Name\n";
+            cout << "2. Edit Age\n";
+            cout << "3. Edit Gender\n";
+            cout << "4. Edit Balance\n";
+            cout << "0. Save and Return\n";
+
+            editChoice = promptIntInRange(
+                "Choose a field to edit: ",
+                0,
+                4,
+                "Invalid choice. Enter a number from 0 to 4."
+            );
+
+            switch (editChoice)
+            {
+            case 1:
+                updatedContact.name = promptRequiredText(
+                    "Enter new name: ",
+                    "Name cannot be empty."
+                );
+                cout << "Name updated." << '\n';
+                break;
+            case 2:
+                updatedContact.age = static_cast<unsigned int>(promptIntInRange(
+                    "Enter new age: ",
+                    0,
+                    150,
+                    "Invalid age. Enter a whole number from 0 to 150."
+                ));
+                cout << "Age updated." << '\n';
+                break;
+            case 3:
+                updatedContact.gender = promptGender(
+                    "Enter new gender (M/F): ",
+                    "Invalid gender. Enter M or F."
+                );
+                cout << "Gender updated." << '\n';
+                break;
+            case 4:
+                updatedContact.balance = promptFloatInRange(
+                    "Enter new balance: ",
+                    0.0f,
+                    1000000.0f,
+                    "Invalid balance. Enter a non-negative number."
+                );
+                cout << "Balance updated." << '\n';
+                break;
+            case 0:
+                break;
+            }
+        }
+        while (editChoice != 0);
+
+        if (book.updateContact(contact->id, updatedContact))
+        {
+            cout << "Contact updated for ID " << contact->id << "." << '\n';
+        }
+        else
+        {
+            cout << "Contact with ID " << contact->id << " not found." << '\n';
+        }
+    }
+    
+    void handleDeactivateContact(ContactBook& book)
+    {
+        if (book.all().empty())
+        {
+            cout << "There are no contacts to deactivate." << '\n';
+            return;
+        }
+
+        int id = promptIntInRange(
+            "Enter Contact ID to deactivate: ",
+            1,
+            1000000,
+            "Invalid ID. Enter a positive whole number."
+        );
+
+        DeactivateResult result = book.deactivate(id);
+
+        switch (result)
+        {
+        case DeactivateResult::Success:
+            cout << "Contact deactivated." << '\n';
+            break;
+        case DeactivateResult::AlreadyInactive:
+            cout << "Contact is already inactive." << '\n';
+            break;
+        case DeactivateResult::NotFound:
+            cout << "Contact with ID " << id << " not found." << '\n';
+            break;
+        }
+    }
+
+    void handleDisplayActiveContacts(const ContactBook& book)
+    {
+        if (book.all().empty())
+        {
+            cout << "There are no contacts to display." << '\n';
+            return;
+        }
+
+        printContacts(book.getContacts((ContactFilter::Active)));
+    }
+
+    void handleDisplayFilteredContacts(const ContactBook& book)
+    {
+        if (book.all().empty())
+        {
+            cout << "There are no contacts to display." << '\n';
+            return;
+        }
+
+        cout << "1. View All Contacts" << '\n';
+        cout << "2. View Inactive Contacts" << '\n';
+
+        int choice = promptIntInRange(
+            "Choose a view: ",
+            1,
+            2,
+            "Invalid choice. Enter a number from 1 to 2."
+        );
+
+        ContactFilter filter = (choice == 1)
+                                   ? ContactFilter::All
+                                   : ContactFilter::Inactive;
+
+        printContacts(book.getContacts(filter));
+    }
 }
 
 // Contact manager menu
@@ -36,214 +295,22 @@ void contactMenu(ContactBook& book)
 
     do
     {
-        cout << "****************************************************" << '\n';
-        cout << "*         Welcome to Contact Manager!              *" << '\n';
-        cout << "*           1. Add Contact                         *" << '\n';
-        cout << "*           2. Display Contacts                    *" << '\n';
-        cout << "*           3. Search Contact by ID                *" << '\n';
-        cout << "*           4. Edit Contact                        *" << '\n';
-        cout << "*           5. Deactivate Contact                  *" << '\n';
-        cout << "*           0. Exit                                *" << '\n';
-        cout << "****************************************************" << '\n';
-
+        printMainMenu();
         userSelection = promptIntInRange(
             "Enter your choice: ",
             0,
-            5,
-            "Invalid choice. Enter a number from 0 to 5."
+            6,
+            "Invalid choice. Enter a number from 0 to 6."
         );
 
         switch (userSelection)
         {
-        case 1:
-            {
-                Contact newContact;
-                newContact.name = promptRequiredText(
-                    "Enter Name: ",
-                    "Name cannot be empty."
-                );
-                newContact.age = static_cast<unsigned int>(promptIntInRange(
-                    "Enter Age: ",
-                    0,
-                    150,
-                    "Invalid age. Enter a whole number from 0 to 150."
-                ));
-                newContact.gender = promptGender(
-                    "Enter Gender (M/F): ",
-                    "Invalid gender. Enter M or F."
-                );
-                newContact.balance = promptFloatInRange(
-                    "Enter Balance: ",
-                    0.0f,
-                    1000000.0f,
-                    "Invalid balance. Enter a non-negative number."
-                );
-                newContact.isActive = true;
-
-                int assignedId = book.add(newContact);
-                cout << "Contact added successfully! ID: " << assignedId << '\n';
-            }
-            break;
-        case 2:
-            {
-                if (book.all().empty())
-                {
-                    cout << "There are no contacts to display." << '\n';
-                    break;
-                }
-
-                cout << std::setw(10) << std::left << "ID"
-                    << std::setw(20) << std::left << "Name"
-                    << std::setw(10) << std::left << "Age"
-                    << std::setw(10) << std::left << "Gender"
-                    << std::setw(15) << std::left << "Balance"
-                    << std::setw(10) << std::left << "Active" << '\n';
-                for (const Contact& contact : book.all())
-                {
-                    cout << std::setw(10) << contact.id
-                        << std::setw(20) << contact.name
-                        << std::setw(10) << contact.age
-                        << std::setw(10) << contact.gender
-                        << std::setw(15) << contact.balance
-                        << std::setw(10) << (contact.isActive ? "Yes" : "No") << '\n';
-                }
-                break;
-            }
-        case 3:
-            {
-                if (book.all().empty())
-                {
-                    cout << "There are no contacts to search." << '\n';
-                    break;
-                }
-
-                int id = promptIntInRange(
-                    "Enter Contact ID to search: ",
-                    1,
-                    1000000,
-                    "Invalid ID. Enter a positive whole number."
-                );
-
-                const Contact* contact = book.findById(id);
-
-                if (contact != nullptr)
-                {
-                    cout << std::setw(10) << contact->id
-                        << std::setw(20) << contact->name
-                        << std::setw(10) << contact->age
-                        << std::setw(10) << contact->gender
-                        << std::setw(15) << contact->balance
-                        << std::setw(10) << (contact->isActive ? "Yes" : "No") << '\n';
-                }
-                else
-                {
-                    cout << "Contact with ID " << id << " not found." << '\n';
-                }
-                break;
-            }
-        case 4:
-            {
-                if (book.all().empty())
-                {
-                    cout << "There are no contacts to edit." << '\n';
-                    break;
-                }
-
-                Contact* contact = promptForExistingContact(
-                    book,
-                    "Enter Contact ID to edit: "
-                );
-                Contact updatedContact = *contact;
-                int editChoice;
-
-                do
-                {
-                    cout << "1. Edit Name\n";
-                    cout << "2. Edit Age\n";
-                    cout << "3. Edit Gender\n";
-                    cout << "4. Edit Balance\n";
-                    cout << "0. Save and Return\n";
-
-                    editChoice = promptIntInRange(
-                        "Choose a field to edit: ",
-                        0,
-                        4,
-                        "Invalid choice. Enter a number from 0 to 4."
-                    );
-
-                    switch (editChoice)
-                    {
-                    case 1:
-                        updatedContact.name = promptRequiredText(
-                            "Enter new name: ",
-                            "Name cannot be empty."
-                        );
-                        cout << "Name updated." << '\n';
-                        break;
-                    case 2:
-                        updatedContact.age = static_cast<unsigned int>(promptIntInRange(
-                            "Enter new age: ",
-                            0,
-                            150,
-                            "Invalid age. Enter a whole number from 0 to 150."
-                        ));
-                        cout << "Age updated." << '\n';
-                        break;
-                    case 3:
-                        updatedContact.gender = promptGender(
-                            "Enter new gender (M/F): ",
-                            "Invalid gender. Enter M or F."
-                        );
-                        cout << "Gender updated." << '\n';
-                        break;
-                    case 4:
-                        updatedContact.balance = promptFloatInRange(
-                            "Enter new balance: ",
-                            0.0f,
-                            1000000.0f,
-                            "Invalid balance. Enter a non-negative number."
-                        );
-                        cout << "Balance updated." << '\n';
-                        break;
-                    case 0:
-                        break;
-                    }
-                }
-                while (editChoice != 0);
-
-                if (book.updateContact(contact->id, updatedContact))
-                {
-                    cout << "Contact updated for ID " << contact->id << "." << '\n';
-                }
-                else
-                {
-                    cout << "Contact with ID " << contact->id << " not found." << '\n';
-                }
-                break;
-            }
-        case 5:
-            {
-                if (book.all().empty())
-                {
-                    cout << "There are no contacts to deactivate." << '\n';
-                    break;
-                }
-
-                Contact* contact = promptForExistingContact(
-                    book,
-                    "Enter Contact ID to deactivate: "
-                );
-
-                if (book.deactivate(contact->id))
-                {
-                    cout << "Contact deactivated." << '\n';
-                }
-                else
-                {
-                    cout << "Contact with ID " << contact->id << " not found." << '\n';
-                }
-                break;
-            }
+        case 1: handleAddContact(book); break;
+        case 2: handleDisplayActiveContacts(book); break;
+        case 3: handleSearchContactById(book); break;
+        case 4: handleEditContact(book); break;
+        case 5: handleDeactivateContact(book); break;
+        case 6: handleDisplayFilteredContacts(book); break;
         case 0:
             cout << "Exiting Contact Manager. Goodbye!" << '\n';
             break;


### PR DESCRIPTION
## Summary
- add explicit soft-delete support in ContactBook with active, inactive, and all filtered views
- refactor ContactMenu into focused workflow helpers and keep active contacts as the default listing
- document the soft-delete behavior in the README, including inactive search behavior

## Testing
- cmake -S . -B build-refactor -G Ninja -DCMAKE_BUILD_TYPE=Release
- cmake --build build-refactor
- manual soft-delete workflow via stdin-driven CLI session against build-refactor/contact_manager.exe
- empty-state regression for display, search, edit, deactivate, and filtered view flows